### PR TITLE
Update _links.less

### DIFF
--- a/less/_links.less
+++ b/less/_links.less
@@ -6,25 +6,8 @@ a {
     transition:         color .3s ease-in-out;
   }
 
-a:link    {
-  color: @blue;
-  -webkit-transition: color .3s ease-in-out;
-  transition:         color .3s ease-in-out;
-}
-
-a:visited {
-  color: @purple;
-}
-
-a:hover   {
-  color: @aqua;
-  -webkit-transition: color .3s ease-in-out;
-  transition:         color .3s ease-in-out;
-}
-
-a:active  {
-  color: @orange;
-  -webkit-transition: color .3s ease-in-out;
-  transition:         color .3s ease-in-out;
-}
+a:link    { color: @blue;   }
+a:visited { color: @purple; }
+a:hover   { color: @aqua;   }
+a:active  { color: @orange; }
 


### PR DESCRIPTION
Removes useless transition (it's already in the global a tag).

I looked at the stylus ones (that I use) and they don't have it too. If this is not the intended behaviour, perhaps it's the stylus that needs an update.
