### PR TITLE
Adding ID's with color names so they're linkable

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,50 +33,64 @@
       <div class="w-25 db fl default-navy pam white">
         <h1 class="man f3">Navy</h1>
         <h2 class="thin man f3 small">#000080</h2>
-        </div><div class="w-25 pam db fl default-blue  white">
+      </div>
+      <div class="w-25 pam db fl default-blue  white">
         <h1 class="man f3">Blue</h1>
         <h2 class="thin man f3 small">#0000ff</h2>
-        </div><div class="w-25 pam db fl default-aqua ">
+      </div>
+      <div class="w-25 pam db fl default-aqua ">
         <h1 class="man f3">Aqua</h1>
         <h2 class="thin man f3 small">#00ffff</h2>
-        </div><div class="w-25 pam db fl default-teal ">
+      </div>
+      <div class="w-25 pam db fl default-teal ">
         <h1 class="man f3">Teal</h1>
         <h2 class="thin man f3 small">#008080</h2>
-        </div><div class="w-25 pam db fl default-olive ">
+      </div>
+      <div class="w-25 pam db fl default-olive ">
         <h1 class="man f3">Olive</h1>
         <h2 class="thin man f3 small">#008000</h2>
-        </div><div class="w-25 pam db fl default-green ">
+      </div>
+      <div class="w-25 pam db fl default-green ">
         <h1 class="man f3">Green</h1>
         <h2 class="thin man f3 small">#008000</h2>
-        </div><div class="w-25 pam db fl default-lime ">
+      </div>
+      <div class="w-25 pam db fl default-lime ">
         <h1 class="man f3">Lime</h1>
         <h2 class="thin man f3 small">#00ff00</h2>
-        </div>
-        <div class="w-25 pam db fl default-yellow ">
+      </div>
+      <div class="w-25 pam db fl default-yellow ">
         <h1 class="man f3">Yellow</h1>
         <h2 class="thin man f3 small">#ffff00</h2>
-        </div><div class="w-25 pam db fl default-orange ">
+      </div>
+      <div class="w-25 pam db fl default-orange ">
         <h1 class="man f3">Orange</h1>
         <h2 class="thin man f3 small">#ffa500</h2>
-        </div><div class="w-25 pam db fl default-red ">
+      </div>
+      <div class="w-25 pam db fl default-red ">
         <h1 class="man f3">Red</h1>
         <h2 class="thin man f3 small">#ff0000</h2>
-        </div><div class="w-25 pam db fl default-maroon white ">
+      </div>
+      <div class="w-25 pam db fl default-maroon white ">
         <h1 class="man f3">Maroon</h1>
         <h2 class="thin man f3 small">#800000</h2>
-        </div><div class="w-25 pam db fl default-fuchsia ">
+      </div>
+      <div class="w-25 pam db fl default-fuchsia ">
         <h1 class="man f3">Fuchsia</h1>
         <h2 class="thin man f3 small">#ff00ff</h2>
-        </div><div class="w-25 pam db fl default-purple  white">
+      </div>
+      <div class="w-25 pam db fl default-purple  white">
         <h1 class="man f3">Purple</h1>
         <h2 class="thin man f3 small">#800080</h2>
-        </div><div class="w-25 pam db fl default-silver ">
+      </div>
+      <div class="w-25 pam db fl default-silver ">
         <h1 class="man f3">Silver</h1>
         <h2 class="thin man f3 small">#c0c0c0</h2>
-        </div><div class="w-25 pam db fl default-gray ">
+      </div>
+      <div class="w-25 pam db fl default-gray ">
         <h1 class="man f3">Gray</h1>
         <h2 class="thin man f3 small">#808080</h2>
-        </div><div class="w-25 pam db fl default-black white">
+      </div>
+      <div class="w-25 pam db fl default-black white">
         <h1 class="man f3">Black</h1>
         <h2 class="thin man f3 small">#000000</h2>
       </div>
@@ -90,71 +104,71 @@
           Minified and gzipped it's a whopping <b>389 Bytes</b>.
         </h2>
       </header>
-      <div class="bg-navy w-100 fl white pas">
+      <div id="navy" class="bg-navy w-100 fl white pas">
         <h1 class="dib title mw-160">NAVY</h1>
         <h2 class="thin dib title small">#001f3f</h2>
       </div>
-      <div class="bg-blue w-100 fl pas">
+      <div id="blue" class="bg-blue w-100 fl pas">
         <h1 class="dib title mw-160">BLUE</h1>
         <h2 class="thin dib title small">#0074d9</h2>
       </div>
-      <div class="bg-aqua w-100 fl pas">
+      <div id="aqua" class="bg-aqua w-100 fl pas">
         <h1 class="dib title mw-160">AQUA</h1>
         <h2 class="thin dib title small">#7fdbff</h2>
       </div>
-      <div class="bg-teal w-100 fl pas">
+      <div id="teal" class="bg-teal w-100 fl pas">
         <h1 class="dib title mw-160">TEAL</h1>
         <h2 class="thin dib title small">#39cccc</h2>
       </div>
-      <div class="bg-olive w-100 fl pas">
+      <div id="olive" class="bg-olive w-100 fl pas">
         <h1 class="dib title mw-160">OLIVE</h1>
         <h2 class="thin dib title small">#3d9970</h2>
       </div>
-      <div class="bg-green w-100 fl pas">
+      <div id="green" class="bg-green w-100 fl pas">
         <h1 class="dib title mw-160">GREEN</h1>
         <h2 class="thin dib title small">#2ecc40</h2>
       </div>
-      <div class="bg-lime w-100 fl pas">
+      <div id="lime" class="bg-lime w-100 fl pas">
         <h1 class="dib title mw-160">LIME</h1>
         <h2 class="thin dib title small">#01ff70</h2>
       </div>
-      <div class="bg-yellow w-100 fl pas">
+      <div id="yellow" class="bg-yellow w-100 fl pas">
         <h1 class="dib title mw-160">YELLOW</h1>
         <h2 class="thin dib title small">#ffdc00</h2>
       </div>
-      <div class="bg-orange white w-100 fl pas">
+      <div id="orange" class="bg-orange white w-100 fl pas">
         <h1 class="dib title mw-160">ORANGE</h1>
         <h2 class="thin dib title small">#ff851b</h2>
       </div>
-      <div class="bg-red white w-100 fl pas">
+      <div id="red" class="bg-red white w-100 fl pas">
         <h1 class="dib title mw-160">RED</h1>
         <h2 class="thin dib title small">#ff4136</h2>
       </div>
-      <div class="bg-maroon white w-100 fl pas">
+      <div id="maroon" class="bg-maroon white w-100 fl pas">
         <h1 class="dib title mw-160">MAROON</h1>
         <h2 class="thin dib title small">#85144b</h2>
       </div>
-      <div class="bg-fuchsia white w-100 fl pas">
+      <div id="fuchsia" class="bg-fuchsia white w-100 fl pas">
         <h1 class="dib title mw-160">FUCHSIA</h1>
         <h2 class="thin dib title small">#f012be</h2>
       </div>
-      <div class="bg-purple white w-100 fl pas">
+      <div id="purple" class="bg-purple white w-100 fl pas">
         <h1 class="dib title mw-160">PURPLE</h1>
         <h2 class="thin dib title small">#b10dc9</h2>
       </div>
-      <div class="bg-white w-100 fl pas">
+      <div id="white" class="bg-white w-100 fl pas">
         <h1 class="dib title mw-160">WHITE</h1>
         <h2 class="thin dib title small ">#ffffff</h2>
       </div>
-      <div class="bg-silver w-100 fl pas">
+      <div id="silver" class="bg-silver w-100 fl pas">
         <h1 class="dib title mw-160">SILVER</h1>
         <h2 class="thin dib title small">#dddddd</h2>
       </div>
-      <div class="bg-gray w-100 fl pas">
+      <div id="gray" class="bg-gray w-100 fl pas">
         <h1 class="dib title mw-160">GRAY</h1>
         <h2 class="thin dib title small">#aaaaaa</h2>
       </div>
-      <div class="bg-black w-100 fl pas white">
+      <div id="black" class="bg-black w-100 fl pas white">
         <h1 class="dib title mw-160">BLACK</h1>
         <h2 class="thin dib title small">#111111</h2>
       </div>


### PR DESCRIPTION
This adds ID's with the color names to the respective `div`s.

This way the colors are **a)** shareable and **b)** usable in tools like [Alfred](http://www.alfredapp.com/) (sadly Mac only) or [Launchy](http://www.launchy.net/).

How is that useful? Let's say you remember a couple of CSS names and want to use _the new defaults_. You open Alfred/Launchy, type `color orange` and hit enter. A new tab with the URL `http://clrs.cc/#orange` is opened.

The related snippets would be `http://clrs.cc/#{query}` for Alfred or `http://clrs.cc/#%1` for Launchy.
