### PR TITLE
Add Text Examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,25 +167,25 @@
     </section>
     <section class="pvfl cf" style="border-top:1px dotted #ccc;">
       <div class="center cf" style="max-width: 64em;">
-        <h1 class="f5 w-100 fl pas">Borders</h1>
-        <div class="fl w-50 pas"><div class="mbs pam border border--navy "></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--blue"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--aqua"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--teal"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--olive"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--green "></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--lime  "></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--yellow "></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--orange"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--red"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--maroon"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--fuchsia "></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--purple"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--black"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--silver"></div></div>
-        <div class="fl w-50 pas"><div class="mbs pam border border--gray"></div></div>
+        <h1 class="f5 w-100 fl pas">Borders & Text</h1>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--navy navy">Navy</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--blue blue">Blue</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--aqua aqua">Aqua</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--teal teal">Teal</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--olive olive">Olive</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--green green">Green</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--lime lime">Lime</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--yellow yellow">Yellow</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--orange orange">Orange</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--red red">Red</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--maroon maroon">Maroon</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--fuchsia fuchsia">Fuchsia</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--purple purple">Purple</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--black black">Black</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--silver silver">Silver</div></div>
+        <div class="fl w-50 pas"><div style="padding:0.45rem" class="mbs border border--gray gray">Gray</div></div>
         <div class="fl wi-100 bg-aqua">
-          <div class="fl w-50 pas"><div class="mbs pam border border--white"></div></div>
+          <div class="fl w-100 pas"><div class="mbs pam border border--white white">White</div></div>
 
         </div>
         <div class="fl wi-100 mtl pas dn">
@@ -448,4 +448,3 @@
     </script>
   </body>
 </html>
-


### PR DESCRIPTION
There were backgrounds, borders, and fills, but no text examples on this page. I added the color names into the border boxes. I kept the 35px height by adjusting the padding from `1rem` to `0.45rem`.

Preview [here](https://daawesomep.github.io/colors/) (from my fork).
