### PR TITLE
fix a typo: Node.js `modules` → `module` actually

### DIFF
--- a/js/colors.js
+++ b/js/colors.js
@@ -19,8 +19,8 @@ var colors = {
 };
 
 if(
-	typeof modules !== "undefined" &&
-	typeof modules.exports !== "undefined"
+	typeof module !== "undefined" &&
+	typeof module.exports !== "undefined"
 ){
-	modules.exports = colors;
+	module.exports = colors;
 }


### PR DESCRIPTION
Fixes an unnoticed typo in #53 that prevented #53 from being useful.
