### PR TITLE
Fix padding on utilities header

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,8 +196,7 @@
       </section>
       <section class="phm pvl pvx-ns" style="border-top:1px dotted #ccc;">
         <div class="center cf" style="max-width: 64em;">
-          <h1 class="f2 f1-ns man thin title"><a href="#utilities" class="black">
-Utilities</a></h1>
+          <h1 class="f2 f1-ns pas man thin title"><a href="#utilities" class="black">Utilities</a></h1>
           <h1 class="f5 w-100 pas fl">Borders & Text</h1>
 <p class="pas f3-ns">
   Includes classes to set text and or border color.


### PR DESCRIPTION
The *Utilities* header needed a little bit of padding for it to line up with everything else:

<img width="548" alt="screen shot 2015-08-13 at 2 26 46 pm" src="https://cloud.githubusercontent.com/assets/5074763/9258092/6b65699e-41c7-11e5-8844-4888231fb82a.png">

So I just added the same `.pas` as is on the other components.