### PR TITLE
Fix typo in `yellow` class

### DIFF
--- a/a11y/index.html
+++ b/a11y/index.html
@@ -1376,7 +1376,7 @@
           </p>
         </div>
         </article>
-        <article class="phm bg-navy yello">
+        <article class="phm bg-navy yellow">
           <div class="center mw-48 pvl pvx-ns">
           <h1 class="mtn mega-ns">AAA</h1>
           <h2 class="f1-ns">Contrast 12.22</h2>


### PR DESCRIPTION
Spotted a typo in the class name.