### PR TITLE
Add TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+interface Colors {
+  blue: string
+  aqua: string
+  lime: string
+  navy: string
+  teal: string
+  olive: string
+  green: string
+  red: string
+  maroon: string
+  orange: string
+  purple: string
+  yellow: string
+  fuchsia: string
+  gray: string
+  white: string
+  black: string
+  silver: string
+}
+
+declare const colors: Colors
+
+export = colors


### PR DESCRIPTION
```ts
import * as colors from 'colors.css'
import {teal} from 'colors.css'

console.log(teal)
console.log(colors.navy)
console.log(colors.blello) // Property 'blello' does not exist on type 'Colors'
```