### PR TITLE
adding best color to suit the smarter defaults

### DIFF
--- a/src/_skins.css
+++ b/src/_skins.css
@@ -120,17 +120,16 @@
 
 /* Foregrounds */
 
-
-.navy-fg{     color: var(--navyfg);}
-.blue-fg{     color: var(--bluefg);}
-.aqua-fg{     color: var(--aquafg);}
-.teal-fg{     color: var(--tealfg);}
-.olive-fg{    color: var(--olivefg);}
-.green-fg{    color: var(--greenfg);}
-.lime-fg{     color: var(--limefg);}
-.yellow-fg{   color: var(--yellowfg);}
-.orange-fg{   color: var(--orangefg);}
-.red-fg{      color: var(--redfg);}
-.fuchsia-fg{  color: var(--fuchsiafg);}
-.purple-fg{   color: var(--purplefg);}
-.maroon-fg{   color: var(--maroonfg);}
+.navy-fg {     color: var(--navyfg);}
+.blue-fg {     color: var(--bluefg);}
+.aqua-fg {     color: var(--aquafg);}
+.teal-fg {     color: var(--tealfg);}
+.olive-fg {    color: var(--olivefg);}
+.green-fg {    color: var(--greenfg);}
+.lime-fg {     color: var(--limefg);}
+.yellow-fg {   color: var(--yellowfg);}
+.orange-fg {   color: var(--orangefg);}
+.red-fg {      color: var(--redfg);}
+.fuchsia-fg {  color: var(--fuchsiafg);}
+.purple-fg {   color: var(--purplefg);}
+.maroon-fg {   color: var(--maroonfg);}

--- a/src/_skins.css
+++ b/src/_skins.css
@@ -6,6 +6,7 @@
    - Border colors
    - SVG fills
    - SVG Strokes
+   - Foregrounds
 
 */
 
@@ -117,3 +118,19 @@
 .stroke-silver {  stroke: var(--silver); }
 .stroke-black {   stroke: var(--black); }
 
+/* Foregrounds */
+
+
+.navy-fg{     color: var(--navyfg);}
+.blue-fg{     color: var(--bluefg);}
+.aqua-fg{     color: var(--aquafg);}
+.teal-fg{     color: var(--tealfg);}
+.olive-fg{    color: var(--olivefg);}
+.green-fg{    color: var(--greenfg);}
+.lime-fg{     color: var(--limefg);}
+.yellow-fg{   color: var(--yellowfg);}
+.orange-fg{   color: var(--orangefg);}
+.red-fg{      color: var(--redfg);}
+.fuchsia-fg{  color: var(--fuchsiafg);}
+.purple-fg{   color: var(--purplefg);}
+.maroon-fg{   color: var(--maroonfg);}

--- a/src/_variables.css
+++ b/src/_variables.css
@@ -30,4 +30,18 @@
 --gray:   #AAAAAA;
 --black:  #111111;
 
+--navyfg:   #80BFFF;
+--bluefg:   #B3DBFF;
+--aquafg:   #004966;
+--tealfg:   #000;
+--olivefg:  #163728;
+--greenfg:  #0E3E14;
+--limefg:   #00662C;
+--yellowfg: #665800;
+--orangefg: #663000;
+--redfg:    #800600;
+--fuchsiafg:#65064F;
+--purplefg: #EFA9F9;
+--maroonfg: #EB7AB1;
+
 }


### PR DESCRIPTION
I loved the idea of using e.g. #80BFFF text color for #001F3F background. So I converted your websites hsla colors to hex and used them as variables. NOTE: I had not build this repo,