### PR TITLE
Fix button in mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         </div>
       </div>
       </section>
-      <section class='tc'>
+      <section class='tc flex' style='flex-wrap: wrap; justify-content: center; gap: 5px'>
         <a href='https://components.ai/theme/DIgsnuGL20I1ZwsNP3YY'
            style='
             color: #001f3f;


### PR DESCRIPTION
The button for "Create your own defaults" was breaking on a small viewport so I used flexbox to center the buttons and allow them to wrap when there is insufficient space.